### PR TITLE
`cargo install --git` multiple packages with binaries found hint

### DIFF
--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -631,7 +631,7 @@ where
 
     fn multi_err<T>(kind: &str, source: &T, mut pkgs: Vec<&Package>) -> String
     where
-    T: Source
+        T: Source,
     {
         pkgs.sort_unstable_by_key(|a| a.name());
         let first_pkg = pkgs.iter().nth(0).unwrap();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -4,7 +4,7 @@ use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::path::Path;
 
-use cargo_test_support::{compare};
+use cargo_test_support::compare;
 use cargo_test_support::cross_compile;
 use cargo_test_support::git;
 use cargo_test_support::registry::{self, registry_path, Package};
@@ -572,14 +572,14 @@ fn multiple_binaries_error() {
     cargo_process("install --git")
         .arg(p.url().to_string())
         .with_status(101)
-        .with_stderr(
-            format!("\
+        .with_stderr(format!(
+            "\
 [UPDATING] git repository [..]
 [ERROR] multiple packages with binaries found: bar, foo. \
 When installing a git repository, cargo will always search the entire repo for any Cargo.toml.\n\
 Please specify a package, e.g. `cargo install --git {git_url} bar`.
-"),
-        )
+"
+        ))
         .run();
 }
 
@@ -591,18 +591,20 @@ fn multiple_examples_error() {
         .file("examples/ex1.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
-        .file("bar/examples/ex1.rs", "fn main() {}",)
+        .file("bar/examples/ex1.rs", "fn main() {}")
         .build();
-    
+
     let git_url = p.url().to_string();
     cargo_process("install --example ex1 --git")
         .arg(p.url().to_string())
         .with_status(101)
-        .with_stderr(format!("\
+        .with_stderr(format!(
+            "\
 [UPDATING] git repository [..]
 [ERROR] multiple packages with examples found: bar, foo. \
 When installing a git repository, cargo will always search the entire repo for any Cargo.toml.\n\
-Please specify a package, e.g. `cargo install --git {git_url} bar`."))
+Please specify a package, e.g. `cargo install --git {git_url} bar`."
+        ))
         .run();
 }
 
@@ -767,7 +769,6 @@ fn multiple_crates_auto_examples() {
         .run();
     assert_has_installed_exe(cargo_home(), "foo");
 }
-
 
 #[cargo_test]
 fn no_binaries_or_examples() {


### PR DESCRIPTION


namely this one:
> 4. a multiple packages with binaries found error should give users a hint about how to specify a single crate

### Before
cargo 1.68.0 (115f34552 2023-02-26)
![image](https://user-images.githubusercontent.com/14891742/224546157-d9b48bfd-f896-4fd1-9f0a-e04a3ad60ae2.png)

### After
![image](https://user-images.githubusercontent.com/14891742/224546182-d4b451ae-1b28-41b6-9d74-db860532512b.png)


